### PR TITLE
feat(v2.0): standardize test results, add sensitivity mapping, unify scenario freq, add qtr_method, and improve plotting

### DIFF
--- a/Technic/cm.py
+++ b/Technic/cm.py
@@ -64,6 +64,7 @@ class CM:
         model_cls: Type[ModelBase] = None,
         data_manager: Any = None,
         scen_cls: Type = None,
+        qtr_method: str = 'mean',
     ):
         """
         Initialize CM.
@@ -92,6 +93,7 @@ class CM:
         self.target_exposure = target_exposure
         self.model_cls = model_cls
         self.dm = data_manager
+        self.qtr_method = qtr_method
         
         # Import and set default ScenManager if not provided
         if scen_cls is None:
@@ -157,7 +159,8 @@ class CM:
                 model_type=self.model_type,
                 target_base=self.target_base,
                 target_exposure=self.target_exposure,
-                scen_cls=self.scen_cls
+                scen_cls=self.scen_cls,
+                qtr_method=self.qtr_method
             ).fit()
 
         # Create full-sample model if requested
@@ -171,7 +174,8 @@ class CM:
                 model_type=self.model_type,
                 target_base=self.target_base,
                 target_exposure=self.target_exposure,
-                scen_cls=self.scen_cls
+                scen_cls=self.scen_cls,
+                qtr_method=self.qtr_method
             ).fit()
 
     @property

--- a/Technic/data.py
+++ b/Technic/data.py
@@ -329,7 +329,7 @@ class DataManager:
         Get the pseudo-out-of-sample periods for Walk Forward Test.
         
         Returns frequency-based defaults if not specified at initialization:
-        - For quarterly data (freq='Q'): [4, 9, 12] 
+        - For quarterly data (freq='Q'): [4, 8, 12] 
         - For monthly data (freq='M'): [3, 6, 12]
         
         Returns
@@ -342,14 +342,14 @@ class DataManager:
         Example
         -------
         >>> periods = dm.poos_periods
-        >>> print(f"POOS periods: {periods}")  # [3, 6, 12] for monthly or [4, 9, 12] for quarterly
+        >>> print(f"POOS periods: {periods}")  # [3, 6, 12] for monthly or [4, 8, 12] for quarterly
         """
         if self._poos_periods is not None:
             return self._poos_periods
         
         # Return frequency-based defaults
         if self.freq == 'Q':
-            return [4, 9, 12]
+            return [4, 8, 12]
         else:  # 'M'
             return [3, 6, 12]
 

--- a/Technic/search.py
+++ b/Technic/search.py
@@ -81,7 +81,8 @@ class ModelSearch:
         model_cls: Type[ModelBase],
         model_type: Optional[Any] = None,
         target_base: Optional[str] = None,
-        target_exposure: Optional[str] = None
+        target_exposure: Optional[str] = None,
+        qtr_method: str = 'mean'
     ):
         self.dm = dm
         self.target = target
@@ -89,6 +90,7 @@ class ModelSearch:
         self.model_type = model_type
         self.target_base = target_base
         self.target_exposure = target_exposure
+        self.qtr_method = qtr_method
         self.all_specs: List[List[Union[str, TSFM, Feature, Tuple[Any, ...]]]] = []
         self.passed_cms: List[CM] = []
         self.failed_info: List[Tuple[List[Any], List[str]]] = []
@@ -333,7 +335,8 @@ class ModelSearch:
             target_base=self.target_base,
             target_exposure=self.target_exposure,
             model_cls=self.model_cls, 
-            data_manager=self.dm
+            data_manager=self.dm,
+            qtr_method=self.qtr_method
         )
         cm.build(specs, sample=sample, outlier_idx=outlier_idx)
         mdl = cm.model_in if sample == 'in' else cm.model_full

--- a/Technic/search.py
+++ b/Technic/search.py
@@ -520,17 +520,39 @@ class ModelSearch:
         if sample not in {'in', 'full'}:
             raise ValueError("sample must be 'in' or 'full'.")
         records = []
+
+        def _flatten_test_result(obj: Any) -> pd.Series:
+            """
+            Convert a test_result (Series or DataFrame) into a flat Series of numeric values.
+            - If DataFrame, prefer 'Value' column; otherwise, the first numeric column.
+            - Returns empty Series if nothing usable.
+            """
+            if obj is None:
+                return pd.Series(dtype=float)
+            if isinstance(obj, pd.Series):
+                return obj.astype(float)
+            if isinstance(obj, pd.DataFrame):
+                if 'Value' in obj.columns:
+                    return obj['Value'].astype(float)
+                numeric_cols = obj.select_dtypes(include=['number']).columns
+                if len(numeric_cols) > 0:
+                    return obj[numeric_cols[0]].astype(float)
+            return pd.Series(dtype=float)
         for cm in cms_list:
             mdl = cm.model_in if sample == 'in' else cm.model_full
             testdict = {t.name: t for t in mdl.testset.tests}
-            fit_sr = testdict['Fit Measures'].test_result
-            is_err_sr = testdict['IS Error Measures'].test_result
-            oos_err_sr = testdict.get('OOS Error Measures')
+            fit_sr = _flatten_test_result(testdict['Fit Measures'].test_result) if 'Fit Measures' in testdict else pd.Series(dtype=float)
+            is_err_sr = _flatten_test_result(testdict['IS Error Measures'].test_result) if 'IS Error Measures' in testdict else pd.Series(dtype=float)
+            oos_err_obj = testdict.get('OOS Error Measures')
+            oos_err_sr = _flatten_test_result(oos_err_obj.test_result) if oos_err_obj is not None else pd.Series(dtype=float)
             rec = {'model_id': cm.model_id}
-            for nm, val in fit_sr.items(): rec[f'fit_{nm}'] = val
-            for nm, val in is_err_sr.items(): rec[f'is_err_{nm}'] = val
-            if oos_err_sr is not None:
-                for nm, val in oos_err_sr.test_result.items(): rec[f'oos_err_{nm}'] = val
+            for nm, val in fit_sr.items():
+                rec[f'fit_{nm}'] = float(val)
+            for nm, val in is_err_sr.items():
+                rec[f'is_err_{nm}'] = float(val)
+            if not oos_err_sr.empty:
+                for nm, val in oos_err_sr.items():
+                    rec[f'oos_err_{nm}'] = float(val)
             records.append(rec)
 
         df = pd.DataFrame(records)

--- a/Technic/segment.py
+++ b/Technic/segment.py
@@ -95,7 +95,8 @@ class Segment:
         export_template_cls: Optional[Type[ExportTemplateBase]] = None,
         reportset_cls: Type[ReportSet] = ReportSet,
         search_cls: Type[ModelSearch] = ModelSearch,
-        scen_cls: Optional[Type[ScenManager]] = None
+        scen_cls: Optional[Type[ScenManager]] = None,
+        qtr_method: str = 'mean'
     ):
         self.segment_id = segment_id
         self.target = target
@@ -107,6 +108,7 @@ class Segment:
         self.export_template_cls = export_template_cls
         self.reportset_cls = reportset_cls
         self.search_cls = search_cls
+        self.qtr_method = qtr_method
         # Import and set default ScenManager if not provided
         if scen_cls is None:
             self.scen_cls = ScenManager
@@ -178,6 +180,7 @@ class Segment:
             data_manager=self.dm,
             model_cls=self.model_cls,
             scen_cls=self.scen_cls,
+            qtr_method=self.qtr_method,
         )
         cm.build(specs, sample=sample)
         self.cms[cm_id] = cm
@@ -1033,7 +1036,8 @@ class Segment:
                 self.model_cls,
                 model_type=self.model_type,
                 target_base=self.target_base,
-                target_exposure=self.target_exposure
+                target_exposure=self.target_exposure,
+                qtr_method=self.qtr_method
             )
         searcher = self.searcher
 

--- a/Technic/sensitivity.py
+++ b/Technic/sensitivity.py
@@ -134,8 +134,7 @@ class SensitivityTest:
         """
         Get parameter names suitable for sensitivity testing.
         
-        Returns parameter names from model.spec_map["StationarityTest"], 
-        excluding constant and dummy variables.
+        Returns parameter names from model.spec_map['SensitivityTest'].
         
         Returns
         -------
@@ -153,11 +152,11 @@ class SensitivityTest:
             return []
         
         spec_map = self.model.spec_map
-        if "StationarityTest" not in spec_map:
+        if "SensitivityTest" not in spec_map:
             return []
         
-        # Get stationarity test variables (excludes dummies and constants)
-        stationarity_vars = spec_map["StationarityTest"]
+        # Get sensitivity test variables (already excludes dummies and constants)
+        sensitivity_vars = spec_map["SensitivityTest"]
         
         # Filter to only include variables that exist in model parameters
         available_params = []
@@ -168,7 +167,7 @@ class SensitivityTest:
         else:
             return []
         
-        for var in stationarity_vars:
+        for var in sensitivity_vars:
             if var in model_params:
                 available_params.append(var)
         


### PR DESCRIPTION
feat(v2.0): standardize test results, add sensitivity mapping, unify scenario freq, add qtr_method, and improve plotting

- tests(ModelTestBase):
  - Standardized test_result across all subclasses: return DataFrame with named index (or a named-index Series only for single-value cases)
  - Added “Example output structure” to each test_result docstring
  - FitMeasure/ErrorMeasure now return DataFrames with index 'Metric' and column 'Value'
  - R2Test remains a Series with index name 'Metric'
  - Set index names where missing (e.g., GroupTest, CoefTest)

- model/spec mapping:
  - Added 'SensitivityTest' to ModelBase.spec_map, excluding 'const' and periodical dummies ('M:*', 'Q:*')
  - sensitivity(SensitivityTest): param_names now uses ModelBase.spec_map['SensitivityTest']

- scenario management and frequency:
  - Added qtr_method parameter (default 'mean') to Segment, CM, ModelBase, ModelSearch; propagated to ScenManager
  - ScenManager qtr_method accepts 'mean' | 'sum' | 'end' (alias 'avg' → 'mean')

- scenario outputs:
  - Removed forecast_y_qtr_df (no longer expose quarterly target aggregation)
  - forecast_y_df, forecast_y_base_df, forecast_y_base_qtr_df:
    - Ensure indices are actual dates
    - Added columns: Actual, Fitted_IS, Pred_OOS
    - Quarterly base aggregation (forecast_y_base_qtr_df): combine monthly Fitted_IS + Pred_OOS prior to aggregation (handles non-quarter-end split), then split aggregated series into Fitted_IS and Pred_OOS by availability; added quarterly Actual

- plotting:
  - plot_forecasts: always show original frequency (row 1: left = target via forecast_y_df, right = base via forecast_y_base_df)
  - If show_qtr=True and freq is monthly, add row 2 right plot (forecast_y_base_qtr_df); left cell hidden for consistent sizing
  - X-axis uses actual dates with automatic tick density (yearly if long, quarterly if medium, monthly if short) and YY-MM formatting; 45° rotation
  - Include Actual (light gray), Fitted_IS (solid), Pred_OOS (dashed, same color as Fitted_IS), plus scenario lines

- fixes:
  - Fixed subplot selection when nrows==1 to avoid numpy.ndarray Axes errors
  - ModelBase.in_perf_measures/out_perf_measures now handle DataFrame test_result by using 'Value' or the sole numeric column

BREAKING CHANGES:
- Removed ScenManager.forecast_y_qtr_df (use forecast_y_df for target and forecast_y_base_qtr_df for base quarterly)
- test_result return types changed (Series → DataFrame in several tests)
- plot_forecasts show_qtr now defaults to False
- qtr_method now restricted to 'mean' | 'sum' | 'end' (with 'avg' alias to 'mean')