### PR TITLE
docs: correct default poos periods

### DIFF
--- a/Technic/data.py
+++ b/Technic/data.py
@@ -54,7 +54,7 @@ class DataManager:
     poos_periods : List[int], optional
         List of integers specifying pseudo-out-of-sample period lengths for Walk Forward Test.
         Each number represents how many periods to use as pseudo out-of-sample ending at
-        the original in-sample end date. If None, defaults to [4, 9, 12] for quarterly 
+        the original in-sample end date. If None, defaults to [4, 8, 12] for quarterly
         data or [3, 6, 12] for monthly data.
 
     Examples


### PR DESCRIPTION
## Summary
- Align DataManager default pseudo-out-of-sample periods with implementation.

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68af052c6c58832b9145a0218031d9f2