### PR TITLE
Add feature caching to DataManager

### DIFF
--- a/Technic/search.py
+++ b/Technic/search.py
@@ -327,10 +327,14 @@ class ModelSearch:
         if sample not in {'in', 'full'}:
             raise ValueError("`sample` must be either 'in' or 'full'.")
 
+        # Ensure feature cache is reset for this assessment
+        if hasattr(self.dm, "clear_feature_cache"):
+            self.dm.clear_feature_cache()
+
         # Build the candidate model
         cm = CM(
-            model_id=model_id, 
-            target=self.target, 
+            model_id=model_id,
+            target=self.target,
             model_type=self.model_type,
             target_base=self.target_base,
             target_exposure=self.target_exposure,


### PR DESCRIPTION
## Summary
- cache feature computations in DataManager.build_features keyed by spec name
- allow resetting feature cache with clear_feature_cache
- reset feature cache during ModelSearch assessments to avoid stale data

## Testing
- `python -m py_compile Technic/data.py Technic/search.py`
- `python - <<'PY'
import types, sys
module = types.ModuleType('tqdm'); module.tqdm = lambda x, *args, **kwargs: x; sys.modules['tqdm'] = module
import pandas as pd, numpy as np, time
from Technic.internal import TimeSeriesLoader
from Technic.mev import MEVLoader
from Technic.data import DataManager
from Technic.transform import TSFM
idx = pd.date_range('2000-01-01', periods=240, freq='M')
internal_df = pd.DataFrame({'A': np.random.randn(len(idx)),
                            'Target': np.random.randn(len(idx))}, index=idx)
mev_df = pd.DataFrame({'GDP': np.random.randn(len(idx))}, index=idx)
il = TimeSeriesLoader(freq='M'); il.load(internal_df)
ml = MEVLoader(); ml.load(mev_df)
DM = DataManager(il, ml)
specs = ['A', TSFM('GDP', 'DF')]
start1 = time.perf_counter(); X1 = DM.build_features(specs); elapsed1 = time.perf_counter() - start1
start2 = time.perf_counter(); X2 = DM.build_features(specs); elapsed2 = time.perf_counter() - start2
same = X1.equals(X2)
X1n = X1.dropna(); X2n = X2.dropna()
y1 = internal_df['Target'].loc[X1n.index]; y2 = internal_df['Target'].loc[X2n.index]
import numpy as np
beta1 = np.linalg.lstsq(X1n.assign(const=1), y1, rcond=None)[0]
beta2 = np.linalg.lstsq(X2n.assign(const=1), y2, rcond=None)[0]
print('first build', elapsed1)
print('second build', elapsed2)
print('dataframe equal', same)
print('coeff equal', np.allclose(beta1, beta2))
PY`

------
https://chatgpt.com/codex/tasks/task_e_68af0b775e6c832bae10abcc901dd621