### PR TITLE
feat: add interpolated vars helper

### DIFF
--- a/Technic/internal.py
+++ b/Technic/internal.py
@@ -41,8 +41,9 @@ class DataLoader(ABC):
     
     Parameters
     ----------
-    freq : str, default='M'
-        Frequency code ('M' for monthly, 'Q' for quarterly)
+    freq : str, optional
+        Frequency code ('M' for monthly, 'Q' for quarterly). If ``None``, the
+        frequency will be inferred from the data.
     full_sample_start : Optional[str], optional
         Start date for full sample period (YYYY-MM-DD)
     full_sample_end : Optional[str], optional
@@ -310,7 +311,7 @@ class DataLoader(ABC):
         Example
         -------
         >>> # Load scenarios from Excel file
-        >>> loader = TimeSeriesLoader(scen_p0="2023-12-31")
+        >>> loader = TimeSeriesLoader(freq="M", scen_p0="2023-12-31")
         >>> loader.load("historical.csv", date_col="date")
         >>> loader.load_scens(
         ...     source="scenarios.xlsx",
@@ -435,7 +436,7 @@ class DataLoader(ABC):
         Example
         -------
         >>> # Load multiple scenario sets
-        >>> loader = TimeSeriesLoader(scen_p0="2023-12-31")
+        >>> loader = TimeSeriesLoader(freq="M", scen_p0="2023-12-31")
         >>> loader.load("historical.csv", date_col="date")
         >>> # Create sample scenarios
         >>> scen_data = {
@@ -488,7 +489,7 @@ class DataLoader(ABC):
         Example
         -------
         >>> # Setup loader with scenario data
-        >>> loader = TimeSeriesLoader(scen_p0="2023-12-31")
+        >>> loader = TimeSeriesLoader(freq="M", scen_p0="2023-12-31")
         >>> # Create sample historical and scenario data
         >>> historical = pd.DataFrame({
         ...     "date": pd.date_range("2023-01-01", "2023-12-31", freq="M"),
@@ -557,7 +558,7 @@ class DataLoader(ABC):
         Example
         -------
         >>> # Setup loader with scenario data
-        >>> loader = TimeSeriesLoader(scen_p0="2023-12-31")
+        >>> loader = TimeSeriesLoader(freq="M", scen_p0="2023-12-31")
         >>> # Create sample data
         >>> historical = pd.DataFrame({
         ...     "date": pd.date_range("2023-01-01", "2023-12-31", freq="M"),
@@ -612,7 +613,8 @@ class DataLoader(ABC):
         >>> loader = PanelLoader(
         ...     entity_col="firm_id",
         ...     date_col="report_date",
-        ...     scen_p0="2023-12-31"
+        ...     scen_p0="2023-12-31",
+        ...     freq="M"
         ... )
         >>> # Create sample panel data
         >>> historical = pd.DataFrame({
@@ -660,8 +662,9 @@ class TimeSeriesLoader(DataLoader):
         Start date for full sample period (YYYY-MM-DD)
     full_sample_end : str, optional
         End date for full sample period (YYYY-MM-DD)
-    freq : str, default='M'
-        Frequency code ('M' for monthly, 'Q' for quarterly)
+    freq : str, optional
+        Frequency code ('M' for monthly, 'Q' for quarterly). If ``None``, the
+        frequency will be inferred from the data.
     scen_p0 : str, optional
         The month-end date that serves as the jumpoff date for scenario forecasting
         
@@ -688,7 +691,8 @@ class TimeSeriesLoader(DataLoader):
     >>> loader = TimeSeriesLoader(
     ...     in_sample_start="2020-01-01",
     ...     in_sample_end="2022-12-31",
-    ...     scen_p0="2023-12-31"
+    ...     scen_p0="2023-12-31",
+    ...     freq="M"
     ... )
     >>> loader.load("data.xlsx", date_col="Date", sheet="Historical")
     >>> loader.load_scens(
@@ -706,7 +710,8 @@ class TimeSeriesLoader(DataLoader):
         in_sample_end: Optional[str] = None,
         full_sample_start: Optional[str] = None,
         full_sample_end: Optional[str] = None,
-        freq: str = 'M',
+        *,
+        freq: Optional[str] = None,
         scen_p0: Optional[str] = None
     ):
         """
@@ -722,8 +727,9 @@ class TimeSeriesLoader(DataLoader):
             Start date for full sample period (YYYY-MM-DD)
         full_sample_end : str, optional
             End date for full sample period (YYYY-MM-DD)
-        freq : str, default='M'
-            Frequency code ('M' for monthly, 'Q' for quarterly)
+        freq : str, optional
+            Frequency code ('M' for monthly, 'Q' for quarterly). If ``None``, the
+            frequency will be inferred from the data.
         scen_p0 : str, optional
             The month-end date that serves as the jumpoff date for scenario forecasting
         """
@@ -988,7 +994,7 @@ class TimeSeriesLoader(DataLoader):
             
         Example
         -------
-        >>> loader = TimeSeriesLoader(in_sample_start="2020-02-01")
+        >>> loader = TimeSeriesLoader(in_sample_start="2020-02-01", freq="M")
         >>> loader.load("data.csv", date_col="date")
         >>> # If data starts from 2020-01-31, p0 would be 2020-01-31
         >>> # If data starts from 2020-02-01 or later, p0 would be None
@@ -1022,7 +1028,8 @@ class TimeSeriesLoader(DataLoader):
         -------
         >>> loader = TimeSeriesLoader(
         ...     in_sample_start="2020-01-01",
-        ...     in_sample_end="2022-12-31"
+        ...     in_sample_end="2022-12-31",
+        ...     freq="M"
         ... )
         >>> loader.load("data.csv", date_col="date")
         >>> out_p0_date = loader.out_p0  # Returns 2022-12-31
@@ -1057,8 +1064,9 @@ class PanelLoader(DataLoader):
         Start date for full sample period
     full_sample_end : str, optional
         End date for full sample period
-    freq : str, default='M'
-        Frequency code ('M' for monthly, 'Q' for quarterly)
+    freq : str, optional
+        Frequency code ('M' for monthly, 'Q' for quarterly). If ``None``, the
+        frequency will be inferred from the data.
     scen_p0 : str, optional
         The month-end date that serves as the jumpoff date for scenario forecasting
         
@@ -1069,7 +1077,8 @@ class PanelLoader(DataLoader):
     ...     entity_col="customer_id",
     ...     date_col="transaction_date",
     ...     split_method="random",
-    ...     test_size=0.2
+    ...     test_size=0.2,
+    ...     freq="M"
     ... )
     >>> loader.load("customer_data.csv")
     >>> in_sample = loader.internal_data.loc[loader.in_sample_idx]
@@ -1084,7 +1093,8 @@ class PanelLoader(DataLoader):
     >>> loader = PanelLoader(
     ...     entity_col="account_id",
     ...     split_method="stratified",
-    ...     test_size=0.25
+    ...     test_size=0.25,
+    ...     freq="M"
     ... )
     >>> loader.load(df, date_col="date")  # Each month will have ~25% of accounts in test set
     
@@ -1095,7 +1105,8 @@ class PanelLoader(DataLoader):
     ...     split_method="time_cutoff",
     ...     in_sample_start="2020-01-01",
     ...     in_sample_end="2022-12-31",
-    ...     scen_p0="2023-12-31"
+    ...     scen_p0="2023-12-31",
+    ...     freq="M"
     ... )
     >>> loader.load("firm_data.xlsx", sheet="Historical")
     >>> loader.load_scens(
@@ -1118,7 +1129,8 @@ class PanelLoader(DataLoader):
         in_sample_end: Optional[str] = None,
         full_sample_start: Optional[str] = None,
         full_sample_end: Optional[str] = None,
-        freq: str = 'M',
+        *,
+        freq: Optional[str] = None,
         scen_p0: Optional[str] = None
     ):
         """
@@ -1144,8 +1156,9 @@ class PanelLoader(DataLoader):
             Start date for full sample period (YYYY-MM-DD)
         full_sample_end : str, optional
             End date for full sample period (YYYY-MM-DD)
-        freq : str, default='M'
-            Frequency code ('M' for monthly, 'Q' for quarterly)
+        freq : str, optional
+            Frequency code ('M' for monthly, 'Q' for quarterly). If ``None``, the
+            frequency will be inferred from the data.
         scen_p0 : str, optional
             The month-end date that serves as the jumpoff date for scenario forecasting
         """
@@ -1203,20 +1216,20 @@ class PanelLoader(DataLoader):
         Example
         -------
         >>> # Load from CSV with custom date column
-        >>> loader = PanelLoader(entity_col="customer_id")
+        >>> loader = PanelLoader(entity_col="customer_id", freq="M")
         >>> loader.load("transactions.csv", date_col="transaction_date")
-        
+
         >>> # Load from Excel with specific sheet
-        >>> loader = PanelLoader(entity_col="account_id", date_col="report_date")
+        >>> loader = PanelLoader(entity_col="account_id", date_col="report_date", freq="M")
         >>> loader.load("account_data.xlsx", sheet="Monthly_Data")
-        
+
         >>> # Load from DataFrame with date standardization
         >>> df = pd.DataFrame({
         ...     "customer_id": [1, 1, 2, 2],
         ...     "date": ["2023-01-15", "2023-02-15", "2023-01-15", "2023-02-15"],
         ...     "balance": [100, 150, 200, 250]
         ... })
-        >>> loader = PanelLoader(entity_col="customer_id")
+        >>> loader = PanelLoader(entity_col="customer_id", freq="M")
         >>> loader.load(df, date_col="date")  # Dates standardized to month-end
         """
         # Update date_col if provided
@@ -1265,7 +1278,7 @@ class PanelLoader(DataLoader):
         ...     "date": ["2023-01-01", "2023-02-01", "2023-01-01", "2023-02-01"],
         ...     "value": [100, 110, 200, 220]
         ... })
-        >>> loader = PanelLoader()
+        >>> loader = PanelLoader(freq="M")
         >>> loader._validate_structure(df_valid, "date")  # No error
         
         >>> # Invalid: duplicate entity-date pair
@@ -1364,20 +1377,21 @@ class PanelLoader(DataLoader):
         ...     "date": pd.date_range("2023-01-01", periods=12, freq="M").repeat(2),
         ...     "value": range(24)
         ... })
-        >>> loader = PanelLoader(split_method="random", test_size=0.25)
+        >>> loader = PanelLoader(split_method="random", test_size=0.25, freq="M")
         >>> loader._split_samples(df)
         >>> in_sample = df.loc[loader.in_sample_idx]
         >>> out_sample = df.loc[loader.out_sample_idx]
         
         >>> # Stratified splitting (by time period)
-        >>> loader = PanelLoader(split_method="stratified", test_size=0.5)
+        >>> loader = PanelLoader(split_method="stratified", test_size=0.5, freq="M")
         >>> loader._split_samples(df)  # Each period has ~50% entities in test set
         
         >>> # Time cutoff splitting
         >>> loader = PanelLoader(
         ...     split_method="time_cutoff",
         ...     in_sample_start="2023-01-01",
-        ...     in_sample_end="2023-06-30"
+        ...     in_sample_end="2023-06-30",
+        ...     freq="M"
         ... )
         >>> loader._split_samples(df)  # Split based on dates
         """
@@ -1443,8 +1457,9 @@ class PPNRInternalLoader(TimeSeriesLoader):
         Start date for full sample period (YYYY-MM-DD)
     full_sample_end : str, optional
         End date for full sample period (YYYY-MM-DD)
-    freq : str, default='M'
-        Frequency code ('M' for monthly, 'Q' for quarterly)
+    freq : str, optional
+        Frequency code ('M' for monthly, 'Q' for quarterly). If ``None``, the
+        frequency will be inferred from the data.
     scen_p0 : str, optional
         The month-end date that serves as the jumpoff date for scenario forecasting
         
@@ -1454,7 +1469,8 @@ class PPNRInternalLoader(TimeSeriesLoader):
     >>> loader = PPNRInternalLoader(
     ...     in_sample_start="2020-01-01",
     ...     in_sample_end="2022-12-31",
-    ...     scen_p0="2023-12-31"
+    ...     scen_p0="2023-12-31",
+    ...     freq="M"
     ... )
     >>> # Create sample data
     >>> historical = pd.DataFrame({
@@ -1495,7 +1511,8 @@ class PPNRInternalLoader(TimeSeriesLoader):
         in_sample_end: Optional[str] = None,
         full_sample_start: Optional[str] = None,
         full_sample_end: Optional[str] = None,
-        freq: str = 'M',
+        *,
+        freq: Optional[str] = None,
         scen_p0: Optional[str] = None
     ):
         # Call parent's __init__ with all parameters
@@ -1523,7 +1540,8 @@ class SMRInternalLoader(PanelLoader):
     >>> # Load account-level data with scenarios
     >>> loader = SMRInternalLoader(
     ...     split_method="random",
-    ...     test_size=0.2
+    ...     test_size=0.2,
+    ...     freq="M"
     ... )
     >>> # Create sample data
     >>> df = pd.DataFrame({

--- a/Technic/search.py
+++ b/Technic/search.py
@@ -662,6 +662,21 @@ class ModelSearch:
         combos = self.build_spec_combos(forced, desired_pool, max_var_num, max_lag, max_periods, category_limit, exp_sign_map)
         print(f"Built {len(combos)} spec combinations.\n")
 
+        # Warn about interpolated MEV variables within the candidate pool
+        vars_to_check: List[Union[str, TSFM]] = []
+
+        def _collect_vars(item: Any) -> None:
+            if isinstance(item, (str, TSFM)):
+                vars_to_check.append(item)
+            elif isinstance(item, (list, tuple, set)):
+                for sub in item:
+                    _collect_vars(sub)
+
+        for item in forced + desired_pool:
+            _collect_vars(item)
+
+        self.dm.interpolated_vars(vars_to_check)
+
         # 3) Filter specs
         passed, failed, errors = self.filter_specs(
             sample=sample,


### PR DESCRIPTION
## Summary
- allow internal loaders to infer data frequency when `freq` is omitted
- source interpolated variable aggregation from `mev_type.xlsx` and display results
- warn about interpolated MEVs during model search only when present

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c04f859d008322894c63dc9d03adbd