### PR TITLE
feat: warn when listing interpolated variables

### DIFF
--- a/Technic/internal.py
+++ b/Technic/internal.py
@@ -41,8 +41,9 @@ class DataLoader(ABC):
     
     Parameters
     ----------
-    freq : str or None
-        Frequency code ('M' for monthly, 'Q' for quarterly). Pass None to infer from data.
+    freq : str or None, optional
+        Frequency code ('M' for monthly, 'Q' for quarterly). Pass ``None`` to infer the
+        frequency from the data.
     full_sample_start : Optional[str], optional
         Start date for full sample period (YYYY-MM-DD)
     full_sample_end : Optional[str], optional
@@ -62,7 +63,7 @@ class DataLoader(ABC):
     
     def __init__(
         self,
-        freq: Optional[str],
+        freq: Optional[str] = None,
         full_sample_start: Optional[str] = None,
         full_sample_end: Optional[str] = None,
         scen_p0: Optional[str] = None
@@ -709,7 +710,7 @@ class TimeSeriesLoader(DataLoader):
         full_sample_start: Optional[str] = None,
         full_sample_end: Optional[str] = None,
         *,
-        freq: Optional[str],
+        freq: Optional[str] = None,
         scen_p0: Optional[str] = None
     ):
         """
@@ -725,8 +726,9 @@ class TimeSeriesLoader(DataLoader):
             Start date for full sample period (YYYY-MM-DD)
         full_sample_end : str, optional
             End date for full sample period (YYYY-MM-DD)
-        freq : str or None
-            Frequency code ('M' for monthly, 'Q' for quarterly). Pass None to infer from data.
+        freq : str or None, optional
+            Frequency code ('M' for monthly, 'Q' for quarterly). Pass ``None`` to infer
+            from the data.
         scen_p0 : str, optional
             The month-end date that serves as the jumpoff date for scenario forecasting
         """
@@ -1126,7 +1128,7 @@ class PanelLoader(DataLoader):
         full_sample_start: Optional[str] = None,
         full_sample_end: Optional[str] = None,
         *,
-        freq: Optional[str],
+        freq: Optional[str] = None,
         scen_p0: Optional[str] = None
     ):
         """
@@ -1152,8 +1154,9 @@ class PanelLoader(DataLoader):
             Start date for full sample period (YYYY-MM-DD)
         full_sample_end : str, optional
             End date for full sample period (YYYY-MM-DD)
-        freq : str or None
-            Frequency code ('M' for monthly, 'Q' for quarterly). Pass None to infer from data.
+        freq : str or None, optional
+            Frequency code ('M' for monthly, 'Q' for quarterly). Pass ``None`` to infer
+            from the data.
         scen_p0 : str, optional
             The month-end date that serves as the jumpoff date for scenario forecasting
         """
@@ -1506,7 +1509,7 @@ class PPNRInternalLoader(TimeSeriesLoader):
         full_sample_start: Optional[str] = None,
         full_sample_end: Optional[str] = None,
         *,
-        freq: Optional[str],
+        freq: Optional[str] = None,
         scen_p0: Optional[str] = None
     ):
         # Call parent's __init__ with all parameters

--- a/Technic/search.py
+++ b/Technic/search.py
@@ -663,18 +663,16 @@ class ModelSearch:
         print(f"Built {len(combos)} spec combinations.\n")
 
         # Warn about interpolated MEV variables within the candidate pool
-        vars_to_check: List[Union[str, TSFM]] = []
+        def _flatten(items: Any) -> List[Union[str, TSFM]]:
+            flat: List[Union[str, TSFM]] = []
+            for it in items:
+                if isinstance(it, (str, TSFM)):
+                    flat.append(it)
+                elif isinstance(it, (list, tuple, set)):
+                    flat.extend(_flatten(it))
+            return flat
 
-        def _collect_vars(item: Any) -> None:
-            if isinstance(item, (str, TSFM)):
-                vars_to_check.append(item)
-            elif isinstance(item, (list, tuple, set)):
-                for sub in item:
-                    _collect_vars(sub)
-
-        for item in forced + desired_pool:
-            _collect_vars(item)
-
+        vars_to_check = _flatten(forced + desired_pool)
         interp_df = self.dm.interpolated_vars(vars_to_check)
         if interp_df is not None:
             print(interp_df.to_string(index=False))


### PR DESCRIPTION
## Summary
- allow DataLoader and its subclasses to infer data frequency when `freq` is omitted
- `DataManager.interpolated_vars` reads aggregation info from `mev_type.xlsx`
- list interpolated variables during `run_search` only when such variables exist

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c0fa05f37c8322aae9c0c5437c873f